### PR TITLE
Improve README and test helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,55 @@
-Ferramenta com interface gráfica para auxiliar o desenvolvimento de modelos SARIMAX, seguindo a metodologia de Box–Jenkins, permitindo a identificação do modelo, com funções de autocorrelação e autocorrelação parcial, estimação dos parâmetros e checagem das premissas estatísticas (teste de autocorrelação dos resíduos). Além do uso de variáveis exógenas ao modelo.
+# Visual SARIMAX
 
-Estamos muito acostumados a utilizar Jupyter notebooks para análise exploratória e desenvolvimento de modelos, mas as vezes queremos alguma solução mais simples e rápida.
+Ferramenta com interface gráfica para auxiliar o desenvolvimento de modelos SARIMAX seguindo a metodologia de Box--Jenkins. O aplicativo permite:
 
-Também existe o caso de pessoas que estão acostumadas a utilizar o Excel e ferramentas como o seu toolbox de análise de dados, mas não sabem programar. O Visual SARIMAX visa atender essas pessoas.
+- Visualização das funções de autocorrelação e autocorrelação parcial;
+- Estimação dos parâmetros do modelo e validação de hipóteses estatísticas (ADF e Ljung--Box);
+- Utilização opcional de variáveis exógenas;
+- Download das projeções geradas.
 
-Esta ferramenta utiliza as bibliotecas:
-- Streamlit;
-- Pmdarima;
-- Numpy;
-- Pandas;
-- Statsmodels;
-- Sklearn;
-- Plotly.
+A interface foi pensada para usuários que nem sempre estão familiarizados com código Python, sendo uma alternativa aos tradicionais notebooks.
 
-Inicialmente deve-se importar um dataset, utilizamos como exemplos os datasets:
-- [AirPassengers](https://www.kaggle.com/chirag19/air-passengers) para modelos SARIMA;
-- [Icecream](https://www3.nd.edu/~busiforc/handouts/Data%20and%20Stories/regression/ice%20cream%20consumption/icecream.html) para modelos com exógenas.
+## Exemplos de uso
 
-**Importando um dataset, o nome dos campos e data e do valor da série temporal é fornecido ao programa, se existir outras colunas elas serão consideradas variáveis exógenas.**
+Alguns datasets de demonstração estão disponíveis no repositório:
 
-![01 - Importação.png](https://github.com/ricardozago/Streamlit_SARIMAX/blob/main/Imagens/01%20-%20Importa%C3%A7%C3%A3o.png)
+- [AirPassengers](https://www.kaggle.com/chirag19/air-passengers)
+- [Icecream](https://www3.nd.edu/~busiforc/handouts/Data%20and%20Stories/regression/ice%20cream%20consumption/icecream.html)
 
-**Escolhendo o modelo SARIMA (é possível utilizar o auto.arima do pacote pmdarima!):**
+Para utilizá‑los selecione a opção desejada na própria aplicação ou importe um arquivo CSV/XLS(X) com as colunas de data e valor da série temporal.
 
-![02 - Parâmetros.png](https://github.com/ricardozago/Streamlit_SARIMAX/blob/main/Imagens/02%20-%20Par%C3%A2metros.png)
+![Importação](https://github.com/ricardozago/Streamlit_SARIMAX/blob/main/Imagens/01%20-%20Importa%C3%A7%C3%A3o.png)
 
-**Verificando a projeção e se os resíduos estão coerentes (conforme metodologia Box–Jenkins):**
+Após escolher os parâmetros SARIMA (ou utilizar o `auto.arima`) visualize a projeção e os testes de diagnóstico:
 
-![03 - Projeção e testes.png](https://github.com/ricardozago/Streamlit_SARIMAX/blob/main/Imagens/03%20-%20Proje%C3%A7%C3%A3o%20e%20testes.png)
+![Projeção e testes](https://github.com/ricardozago/Streamlit_SARIMAX/blob/main/Imagens/03%20-%20Proje%C3%A7%C3%A3o%20e%20testes.png)
 
-Estamos abertos a contribuições!
+## Instalação
 
-## Instalação como biblioteca
-
-Para instalar a aplicação como uma biblioteca Python utilize:
+Instale a aplicação em modo desenvolvimento com:
 
 ```bash
 pip install -e .
 ```
 
-Depois de instalada execute o aplicativo com:
+Em seguida execute o aplicativo com:
 
 ```bash
 streamlit run -m visual_sarimax.app
 ```
+
+## Desenvolvimento
+
+Clone o projeto e instale as dependências listadas em `requirements.txt`. Para rodar os testes automatizados utilize:
+
+```bash
+pytest -q
+```
+
+Contribuições são bem-vindas!
+
+---
+
+## English summary
+
+**Visual SARIMAX** is a Streamlit application that guides you through the Box--Jenkins methodology for SARIMAX models. Import a dataset, choose the model parameters (or rely on `auto.arima`) and inspect the forecast along with diagnostic tests. Run it locally with `streamlit run -m visual_sarimax.app` after installing the package in editable mode.

--- a/plots.py
+++ b/plots.py
@@ -1,0 +1,97 @@
+# Plotting functions for the SARIMAX Streamlit app
+import plotly.graph_objects as go
+import streamlit as st
+
+@st.cache_data
+def plot_auto_correlation(serie, n, versao):
+    """Create an autocorrelation or partial autocorrelation plot."""
+    x = list(range(0, n + 1))
+    y = serie[0]
+    y_upper = serie[1][:, 1] - y
+    y_lower = serie[1][:, 0] - y
+
+    fig = go.Figure(
+        [
+            go.Scatter(x=x, y=y, line_color="red", mode="markers"),
+            go.Bar(x=x, y=y, width=0.1),
+            go.Scatter(x=x, y=y_lower, fill="tonexty", mode="none", line_color="indigo"),
+            go.Scatter(x=x, y=y_upper, fill="tonexty", mode="none", line_color="indigo"),
+        ]
+    )
+    fig.update_layout(
+        showlegend=False,
+        title=versao,
+        xaxis_title="Lags",
+        yaxis_title="Corr",
+        width=500,
+        height=400,
+    )
+    return fig
+
+@st.cache_data
+def plot_grafico_1(df, nome_data, nome_qty, is_data=True):
+    """Plot the imported time series data."""
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(x=list(df[nome_data]), y=list(df[nome_qty])))
+
+    fig.update_layout(title_text="Gráfico da série importada", width=1200, height=400)
+
+    if is_data:
+        fig.update_layout(
+            xaxis=dict(
+                rangeselector=dict(
+                    buttons=list(
+                        [
+                            dict(count=1, label="1m", step="month", stepmode="backward"),
+                            dict(count=6, label="6m", step="month", stepmode="backward"),
+                            dict(count=1, label="YTD", step="year", stepmode="todate"),
+                            dict(count=1, label="1y", step="year", stepmode="backward"),
+                            dict(step="all"),
+                        ]
+                    )
+                ),
+                rangeslider=dict(visible=True),
+                type="date",
+            )
+        )
+    return fig
+
+@st.cache_data
+def plot_grafico_projecao(X_train, X_test, X_pred, nome_data, nome_qty, is_data=True):
+    """Plot training, test and forecasted values."""
+    fig = go.Figure()
+    X_train = X_train.reset_index()
+    X_pred = X_pred.reset_index()
+    fig.add_trace(
+        go.Scatter(x=list(X_train[nome_data]), y=list(X_train[nome_qty]), name="Conjunto Treinamento")
+    )
+
+    if X_test is not None:
+        X_test = X_test.reset_index()
+        fig.add_trace(
+            go.Scatter(x=list(X_test[nome_data]), y=list(X_test[nome_qty]), name="Conjunto Teste")
+        )
+
+    fig.add_trace(go.Scatter(x=X_pred["index"], y=X_pred["predicted_mean"], name="Projeção"))
+
+    fig.update_layout(title_text="Gráfico Observações e Projeção", width=1200, height=400)
+
+    if is_data:
+        fig.update_layout(
+            xaxis=dict(
+                rangeselector=dict(
+                    buttons=list(
+                        [
+                            dict(count=1, label="1m", step="month", stepmode="backward"),
+                            dict(count=6, label="6m", step="month", stepmode="backward"),
+                            dict(count=1, label="YTD", step="year", stepmode="todate"),
+                            dict(count=1, label="1y", step="year", stepmode="backward"),
+                            dict(step="all"),
+                        ]
+                    )
+                ),
+                rangeslider=dict(visible=True),
+                type="date",
+            )
+        )
+    return fig

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,57 @@
+"""Utility functions for the SARIMAX Streamlit app."""
+import streamlit as st
+import statsmodels.tsa.stattools as ts
+
+from plots import plot_auto_correlation
+
+
+def set_session_state():
+    """Initialize default values in Streamlit session state."""
+    if "df" not in st.session_state:
+        st.session_state.df = None
+    if "nome_data" not in st.session_state:
+        st.session_state.nome_data = "DATA"
+    if "nome_qty" not in st.session_state:
+        st.session_state.nome_qty = "QTY"
+    if "is_data" not in st.session_state:
+        st.session_state.is_data = True
+
+
+def download_dataframe(df, file_name="captura.csv"):
+    """Render a button for downloading a dataframe as CSV."""
+    csv = df.to_csv(index=False).encode("utf-8")
+    st.download_button(label="Download CSV", data=csv, file_name=file_name, mime="text/csv")
+
+
+def tests_adf_autocorr(y, texto):
+    """Display ADF test and autocorrelation plots."""
+    statistical_tests = st.expander(texto)
+    with statistical_tests:
+        st.markdown("***")
+        st.markdown("**Teste de estacionariedade de Dickey-Fuller Aumentado (ADF):**")
+        check_adfuller(y)
+        st.markdown("***")
+        c_acf, c_pacf = st.columns(2)
+        acf = ts.acf(y, nlags=min(int(y.shape[0] / 2 - 1), 25), alpha=0.05)
+        c_acf.plotly_chart(plot_auto_correlation(acf, 25, "ACF"), use_container_width=True)
+        pacf = ts.pacf(y, nlags=min(int(y.shape[0] / 2 - 1), 25), alpha=0.05)
+        c_pacf.plotly_chart(plot_auto_correlation(pacf, 25, "PACF"), use_container_width=True)
+
+
+def param_models_text(param_models, par_ARIMA):
+    """Display the selected SARIMAX parameters."""
+    param_models.markdown(
+        f"""
+    Modelo sendo utilizado (notação $(p, d, q)x(P, D, Q, s)$):
+    $({par_ARIMA['p']}, {par_ARIMA['d']}, {par_ARIMA['q']})x({par_ARIMA['P']}, {par_ARIMA['D']}, {par_ARIMA['Q']}, {par_ARIMA['n']})$
+    """
+    )
+
+
+def check_adfuller(y):
+    """Run augmented Dickey-Fuller test and show the result."""
+    est = ts.adfuller(y)[1]
+    if est <= 0.05:
+        st.markdown(f"👍 A série **é estacionária** com p-valor de : {est:.4f}")
+    else:
+        st.markdown(f"👎 A série **não é estacionária** com p-valor de : {est:.4f}")


### PR DESCRIPTION
## Summary
- improve README with install and usage instructions
- add minimal `utils.py` and `plots.py` modules so tests can import them

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b277ef33c832d884369af0ce0cb5e