### PR TITLE
Add dataset loading helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Alguns datasets de demonstração estão disponíveis no repositório:
 
 Para utilizá‑los selecione a opção desejada na própria aplicação ou importe um arquivo CSV/XLS(X) com as colunas de data e valor da série temporal.
 
+Os arquivos de demonstração também podem ser carregados via código:
+
+```python
+from visual_sarimax import load_dataset
+df = load_dataset("AirPassengers")
+```
+
 ![Importação](https://github.com/ricardozago/Streamlit_SARIMAX/blob/main/Imagens/01%20-%20Importa%C3%A7%C3%A3o.png)
 
 Após escolher os parâmetros SARIMA (ou utilizar o `auto.arima`) visualize a projeção e os testes de diagnóstico:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -117,3 +117,9 @@ def test_check_adfuller_non_stationary(utils_setup):
     ts.adfuller = lambda y: [None, 0.1]
     utils.check_adfuller([1, 2, 3])
     assert any('não é estacionária' in m for m in logs)
+
+
+def test_load_dataset(utils_setup):
+    utils, _, _, _, _ = utils_setup
+    df = utils.load_dataset("AirPassengers")
+    assert not df.empty

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,8 @@
 """Utility functions for the SARIMAX Streamlit app."""
 import streamlit as st
 import statsmodels.tsa.stattools as ts
+from pathlib import Path
+import pandas as pd
 
 from plots import plot_auto_correlation
 
@@ -55,3 +57,9 @@ def check_adfuller(y):
         st.markdown(f"👍 A série **é estacionária** com p-valor de : {est:.4f}")
     else:
         st.markdown(f"👎 A série **não é estacionária** com p-valor de : {est:.4f}")
+
+
+def load_dataset(name: str) -> pd.DataFrame:
+    """Return one of the bundled example datasets by name."""
+    data_dir = Path(__file__).resolve().parent / "visual_sarimax" / "datasets"
+    return pd.read_csv(data_dir / f"{name}.csv")

--- a/visual_sarimax/__init__.py
+++ b/visual_sarimax/__init__.py
@@ -1,5 +1,6 @@
 """Visual SARIMAX Streamlit library."""
 
 from .app import main
+from .utils import load_dataset
 
-__all__ = ["main"]
+__all__ = ["main", "load_dataset"]

--- a/visual_sarimax/utils.py
+++ b/visual_sarimax/utils.py
@@ -1,6 +1,8 @@
 """Utility functions for the SARIMAX Streamlit app."""
 import streamlit as st
 import statsmodels.tsa.stattools as ts
+from pathlib import Path
+import pandas as pd
 
 from .plots import plot_auto_correlation
 
@@ -55,3 +57,9 @@ def check_adfuller(y):
         st.markdown(f"👍 A série **é estacionária** com p-valor de : {est:.4f}")
     else:
         st.markdown(f"👎 A série **não é estacionária** com p-valor de : {est:.4f}")
+
+
+def load_dataset(name: str) -> pd.DataFrame:
+    """Return one of the bundled example datasets by name."""
+    data_dir = Path(__file__).resolve().parent / "datasets"
+    return pd.read_csv(data_dir / f"{name}.csv")


### PR DESCRIPTION
## Summary
- add helper `load_dataset` to load sample data
- export `load_dataset` in package
- document usage in README
- test new helper function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ba81cb8d0832db6134373cf8f9f12